### PR TITLE
sub が空配列の場合表示しない

### DIFF
--- a/src/Menu.php
+++ b/src/Menu.php
@@ -43,6 +43,11 @@ class Menu
             }
             $config['child'] = $maxChild;
 
+            // sub が空配列の場合表示しない
+            if (isset($config['sub']) && empty($config['sub'])) {
+                continue;
+            }
+
             // メニューかサブメニューがactive
             if ((isset($config['name']) && self::checkActive($config)) || $isSubActive) {
                 $config['active'] = true;


### PR DESCRIPTION
子メニュー、孫メニューに全て権限がなくとも親メニューが表示される不具合の対応