### PR TITLE
download ファイルが存在しない場合 404 を返す

### DIFF
--- a/controller/FileTrait.php
+++ b/controller/FileTrait.php
@@ -56,6 +56,10 @@ trait FileTrait
         $filename = $this->uploadStorage.'/'.$filename;
 
         $storage = \Storage::disk();
+        if (!$storage->exists($filename)) {
+            // ファイルが存在しない
+            abort(404);
+        }
         $mimeType = $storage->mimeType($filename);
 
         if (isset($size)) {


### PR DESCRIPTION
サムネイル生成処理で 500 になっているため
先にファイルの存在をチェックし、なければ 404 を返す